### PR TITLE
Style table listings so that there is a bottom border and colour nth row

### DIFF
--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/ootbee-support-tools/admin/support-tools/applied-patches.get.html.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/ootbee-support-tools/admin/support-tools/applied-patches.get.html.ftl
@@ -30,7 +30,7 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
         <p class="intro">${msg("appliedPatches.intro")?html}</p>      
   
         <div class="control">
-            <table class="data patchesapplied" width="100%">
+            <table class="data results patchesapplied" width="100%">
                 <thead>
                     <tr>
                         <th>${msg("appliedPatches.id")?html}</th>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/ootbee-support-tools/admin/support-tools/log4j-settings.lib.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/ootbee-support-tools/admin/support-tools/log4j-settings.lib.ftl
@@ -55,7 +55,7 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
         </#if>
         </div>
       
-        <table>
+        <table class="results log4jsettings">
             <tr><th><b>Logger Name</b></th><th><b>Parent Logger Name</b></th><th><b>Setting</b></th><th><b>Effective Value</b></th></tr>
             <#list loggerStates as loggerState>
                 <tr>

--- a/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/ootbee-support-tools/admin/support-tools/scheduled-jobs.get.html.ftl
+++ b/repository/src/main/amp/config/alfresco/templates/webscripts/org/orderofthebee/ootbee-support-tools/admin/support-tools/scheduled-jobs.get.html.ftl
@@ -30,7 +30,7 @@ Copyright (C) 2005-2016 Alfresco Software Limited.
         <p class="intro">${msg("scheduled-jobs.intro-text")?html}</p>      
   
         <div class="control">
-            <table class="data scheduledjobs" width="100%">
+            <table class="data results scheduledjobs" width="100%">
                 <thead>
                     <tr>
                         <th>${msg("scheduled-jobs.table-header.job-name")?html}</th>

--- a/repository/src/main/amp/web/ootbee-support-tools/css/admin.css
+++ b/repository/src/main/amp/web/ootbee-support-tools/css/admin.css
@@ -1,3 +1,10 @@
 div.main-wrapper > div.main {
 	width: 100%;
 }
+
+table.patchesapplied tr:nth-child(even),
+table.scheduledjobs tr:nth-child(even),
+table.log4jsettings tr:nth-child(even)
+{
+   background-color: #f8f8f8;
+}


### PR DESCRIPTION
Style table listings so that there is a bottom border and every second row is a different colour.
- Add the results class to applied-patches, lof4j-settings,
scheduled-jobs.
- Add to admin.css style for tr:nth-child to colour rows