### PR TITLE
Enable travis build / updates to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,15 @@
 .project
 .classpath
 target/
-bin/
+bin/.idea/checkstyle-idea.xml
+.idea/compiler.xml
+.idea/copyright
+.idea/encodings.xml
+.idea/libraries
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml
+.idea/workspace.xml
+ootbee-support-tools-parent.iml
+repository/ootbee-support-tools-repo.iml
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: java
+jdk:
+  - oraclejdk7
+cache:
+  directories:
+  - $HOME/.m2

--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ In an all-in-one project you also need to add the AMP as an <overlay> to the mav
 </plugin>
 ``` 
 
+For Alfresco SDK 3 beta users:
+
+```xml
+<platformModules>
+    <moduleDependency>
+        <groupId>org.orderofthebee.addons</groupId>
+        <artifactId>ootbee-support-tools-repo</artifactId>
+        <version>0.0.1.0-SNAPSHOT</version>
+        <type>amp</type>
+    </moduleDependency>
+</platformModules>
+```
+
 Currently this addon is not yet published to an artifact repository, so before you can use it you need to clone and build it locally using:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/AFaust/ootbee-support-tools.svg?branch=master)](https://travis-ci.org/AFaust/ootbee-support-tools)
+
 # "Liberated" Alfresco Support Tools
 This addon aims to bring the functionality provided by the [Alfresco Support Tools](https://github.com/Alfresco/alfresco-support-tools) addon by Antonio Soler, which is only supported on the Alfresco Enterprise Edition, to the free and open Community Edition of Alfresco.
 


### PR DESCRIPTION
This PR enables travis builds for this addon (which is not as useful as it could be at the moment without any testcases!) and adds an build indicator into the README file.

Additionally the README now contains instructions how to add this dependency to the pom.xml of an alfresco sdk 3 build.

The scheduled job page now displays the running state of each job in the table and will automatically refresh the table in 2 seconds intervall
Currently the status only changes for one job - the nodeServiceCleanupJobDetail... Cause is unknown at the moment...